### PR TITLE
Fix increase-outbound-liquidity example - uses --fee-rate, not --max-fee

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Opens a new channel to increase your outbound liquidity. If you don't specify `w
   - `with`: enter the pubkey to open channel with 
   - `dryrun`: avoids opening the channel but gives you a summary of the channel open
   <br></br>
-  Example: `bos increase-outbound-liquidity --with yourPeerPubkey --max-fee 2000 --dryrun`
+  Example: `bos increase-outbound-liquidity --with yourPeerPubkey --fee-rate 1 --dryrun`
   <br></br>
   <br></br>
 


### PR DESCRIPTION
I got the following error when running the example for `increase-outbound-liquidity`
![image](https://user-images.githubusercontent.com/19941207/149626674-53b29ea0-acc2-4ac5-9a37-cbc3ddde1b63.png)

The `increase-outbound-liquidity` example is using the `--max-fee` flag, but it should be using the `--fee-rate` flag. 